### PR TITLE
Prevent double slash in lyric authentication url

### DIFF
--- a/homeassistant/components/lyric.py
+++ b/homeassistant/components/lyric.py
@@ -124,8 +124,14 @@ def setup(hass, config):
     cache_ttl = conf[CONF_SCAN_INTERVAL]
     filename = LYRIC_CONFIG_FILE
     token_cache_file = hass.config.path(filename)
+    lyric_auth_url = '/api/lyric/authenticate'
+
+    if hass.config.api.base_url.endswith('/'):
+        # strip prefix slash to prevent double slashes in redirect_url
+        lyric_auth_url = lyric_auth_url[1:]
+
     redirect_uri = conf.get(CONF_REDIRECT_URI, hass.config.api.base_url +
-                            '/api/lyric/authenticate')
+                            lyric_auth_url)
 
     lyric = lyric.Lyric(
         token_cache_file=token_cache_file,


### PR DESCRIPTION
Before this patch; If the base_url is configured as https://url:port/ then then
authentication url ends up as:
https://url:port//api/lyric/authenticate

It is fixed by first checking if the base_url ends in
a slash and if it does, string-slicing the first slash from the
authentication url.